### PR TITLE
Update awacs version in lock file

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.lock
+++ b/{{cookiecutter.repo_name}}/pyproject.lock
@@ -5,7 +5,7 @@ name = "awacs"
 optional = false
 platform = "*"
 python-versions = "*"
-version = "0.8.0"
+version = "0.8.2"
 
 [[package]]
 category = "main"


### PR DESCRIPTION
The awacs version was updated in stacker_blueprints, but not here, causing new projects to fail on creation. 